### PR TITLE
Remove deprecation warning, specify 3.x compatability

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 A TypeScript/JavaScript library for inserting and extracting IPFS data to and from Tableland queries using the `@tableland/sdk`.
 
-This library is only compartible with version 3 of `@tableland/sdk`.
+This library is only compatible with version 3 of `@tableland/sdk`.
 
 # Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
-# **Deprecated**
-
-This repository is no longer actively maintained and is deprecated.
-
 # @tableland/jeti (JavaScript Extension for Tableland and IPFS)
 
 [![Lint and test](https://github.com/tablelandnetwork/js-tableland/actions/workflows/lint-and-test.yml/badge.svg)](https://github.com/tablelandnetwork/js-tableland/actions/workflows/lint-and-test.yml)
@@ -11,9 +7,10 @@ This repository is no longer actively maintained and is deprecated.
 
 A TypeScript/JavaScript library for inserting and extracting IPFS data to and from Tableland queries using the `@tableland/sdk`.
 
+This library is only compartible with version 3 of `@tableland/sdk`.
+
 # Table of Contents
 
-- [**Deprecated**](#deprecated)
 - [@tableland/jeti (JavaScript Extension for Tableland and IPFS)](#tablelandjeti-javascript-extension-for-tableland-and-ipfs)
 - [Table of Contents](#table-of-contents)
 - [Background](#background)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableland/jeti",
-  "version": "0.0.3",
-  "description": "DEPRECATED: A TypeScript/JavaScript extension for the @tableland/sdk for inserting and retreiving IPFS content from tables",
+  "version": "0.0.5",
+  "description": "A TypeScript/JavaScript extension for the @tableland/sdk for inserting and retreiving IPFS content from tables",
   "repository": "https://github.com/tablelandnetwork/jeti",
   "license": "MIT",
   "publishConfig": {


### PR DESCRIPTION
Removes deprecation warning, instead specifying that JETI is only compatible with the 3.x version of @tableland/sdk.

- [x] Appropriate changes to README are included in PR
