### PR TITLE
Add official mockipfs release to dev deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "eslint": "^8.40.0",
         "eslint-plugin-import": "^2.27.5",
         "ipfs-http-client": "^56.0.3",
-        "node-fetch": "^3.3.1",
         "prettier": "^2.8.8",
         "ts-node": "^10.9.1"
       },
@@ -32,7 +31,7 @@
         "eslint-config-prettier": "^8.8.0",
         "eslint-config-standard": "^17.0.0",
         "mocha": "^10.0.0",
-        "mockipfs": "npm:@joewagner/mockipfs@^0.3.2",
+        "mockipfs": "^0.3.2",
         "sinon": "^15.0.4",
         "typescript": "^4.2.3",
         "uint8arrays": "^4.0.3"
@@ -3098,6 +3097,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
       "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "peer": true,
       "engines": {
         "node": ">= 12"
       }
@@ -4381,6 +4381,7 @@
           "url": "https://paypal.me/jimmywarting"
         }
       ],
+      "peer": true,
       "dependencies": {
         "node-domexception": "^1.0.0",
         "web-streams-polyfill": "^3.0.3"
@@ -4546,6 +4547,7 @@
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
       "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "peer": true,
       "dependencies": {
         "fetch-blob": "^3.1.2"
       },
@@ -6406,6 +6408,7 @@
           "url": "https://paypal.me/jimmywarting"
         }
       ],
+      "peer": true,
       "engines": {
         "node": ">=10.5.0"
       }
@@ -6414,6 +6417,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.1.tgz",
       "integrity": "sha512-cRVc/kyto/7E5shrWca1Wsea4y6tL9iYJE5FBCius3JQfb/4P4I295PfhgbJQBLTx6lATE4z+wK0rPM4VS2uow==",
+      "peer": true,
       "dependencies": {
         "data-uri-to-buffer": "^4.0.0",
         "fetch-blob": "^3.1.4",
@@ -7982,6 +7986,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
       "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+      "peer": true,
       "engines": {
         "node": ">= 8"
       }
@@ -10328,7 +10333,8 @@
     "data-uri-to-buffer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "peer": true
     },
     "date-fns": {
       "version": "2.29.3",
@@ -11314,6 +11320,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
       "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "peer": true,
       "requires": {
         "node-domexception": "^1.0.0",
         "web-streams-polyfill": "^3.0.3"
@@ -11445,6 +11452,7 @@
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
       "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "peer": true,
       "requires": {
         "fetch-blob": "^3.1.2"
       }
@@ -12850,12 +12858,14 @@
     "node-domexception": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "peer": true
     },
     "node-fetch": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.1.tgz",
       "integrity": "sha512-cRVc/kyto/7E5shrWca1Wsea4y6tL9iYJE5FBCius3JQfb/4P4I295PfhgbJQBLTx6lATE4z+wK0rPM4VS2uow==",
+      "peer": true,
       "requires": {
         "data-uri-to-buffer": "^4.0.0",
         "fetch-blob": "^3.1.4",
@@ -13994,7 +14004,8 @@
     "web-streams-polyfill": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
-      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q=="
+      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+      "peer": true
     },
     "webidl-conversions": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "eslint-config-prettier": "^8.8.0",
     "eslint-config-standard": "^17.0.0",
     "mocha": "^10.0.0",
-    "mockipfs": "npm:@joewagner/mockipfs@^0.3.2",
+    "mockipfs": "^0.3.2",
     "sinon": "^15.0.4",
     "typescript": "^4.2.3",
     "uint8arrays": "^4.0.3"
@@ -82,7 +82,6 @@
     "eslint": "^8.40.0",
     "eslint-plugin-import": "^2.27.5",
     "ipfs-http-client": "^56.0.3",
-    "node-fetch": "^3.3.1",
     "prettier": "^2.8.8",
     "ts-node": "^10.9.1"
   },

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,13 +1,5 @@
-import fetch, { Headers, Request, Response } from "node-fetch";
 import { after, before } from "mocha";
 import { LocalTableland } from "@tableland/local";
-
-if (!globalThis.fetch) {
-  (globalThis as any).fetch = fetch;
-  (globalThis as any).Headers = Headers;
-  (globalThis as any).Request = Request;
-  (globalThis as any).Response = Response;
-}
 
 const getTimeoutFactor = function (): number {
   const envFactor = Number(process.env.TEST_TIMEOUT_FACTOR);


### PR DESCRIPTION
The `mockipfs` package was just released with the version we need.  We can start using that instead of the fork now.